### PR TITLE
Add minimap disable toggle

### DIFF
--- a/CustomStatusEffectsList.cs
+++ b/CustomStatusEffectsList.cs
@@ -21,8 +21,8 @@ namespace MyLittleUI
        
         private static Vector3 GetStatusEffectPosition(int i)
         {
-            float offset = i * (Game.m_noMap ? statusEffectsPositionSpacingNomap.Value + statusEffectsElementSizeNomap.Value : statusEffectsPositionSpacing.Value + statusEffectsElementSize.Value);
-            return (Game.m_noMap ? statusEffectsFillingDirectionNomap.Value : statusEffectsFillingDirection.Value) switch
+            float offset = i * (UseNomapLayout() ? statusEffectsPositionSpacingNomap.Value + statusEffectsElementSizeNomap.Value : statusEffectsPositionSpacing.Value + statusEffectsElementSize.Value);
+            return (UseNomapLayout() ? statusEffectsFillingDirectionNomap.Value : statusEffectsFillingDirection.Value) switch
             {
                 ListDirection.LeftToRight => new Vector3(offset, 0, 0),
                 ListDirection.RightToLeft => new Vector3(-offset, 0, 0),
@@ -55,7 +55,7 @@ namespace MyLittleUI
             m_statusEffectTemplate.gameObject.SetActive(value: false);
             m_statusEffectTemplate.name = templateName;
 
-            int size = Game.m_noMap ? statusEffectsElementSizeNomap.Value : statusEffectsElementSize.Value;
+            int size = UseNomapLayout() ? statusEffectsElementSizeNomap.Value : statusEffectsElementSize.Value;
 
             RectTransform icon = m_statusEffectTemplate.Find("Icon").GetComponent<RectTransform>();
             icon.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, size);
@@ -197,42 +197,42 @@ namespace MyLittleUI
             if (fixStatusEffectAndForecastPosition.Value && instance.Info.Metadata.Version >= new System.Version("1.0.11") && statusEffectsPositionAnchor.Value == new Vector2(-170f, -240f))
                 statusEffectsPositionAnchor.Value = (Vector2)statusEffectsPositionAnchor.DefaultValue;
 
-            return Game.m_noMap ? statusEffectsPositionAnchorNomap.Value : statusEffectsPositionAnchor.Value;
+            return UseNomapLayout() ? statusEffectsPositionAnchorNomap.Value : statusEffectsPositionAnchor.Value;
         }
 
         private static bool GetSailingIndicatorEnabled()
         {
-            return Game.m_noMap ? sailingIndicatorEnabledNomap.Value : sailingIndicatorEnabled.Value;
+            return UseNomapLayout() ? sailingIndicatorEnabledNomap.Value : sailingIndicatorEnabled.Value;
         }
 
         private static Vector2 GetSailingIndicatorWindIndicatorPosition()
         {
-            return Game.m_noMap ? sailingIndicatorWindIndicatorPositionNomap.Value : sailingIndicatorWindIndicatorPosition.Value;
+            return UseNomapLayout() ? sailingIndicatorWindIndicatorPositionNomap.Value : sailingIndicatorWindIndicatorPosition.Value;
         }
 
         private static float GetSailingIndicatorWindIndicatorScale()
         {
-            return Game.m_noMap ? sailingIndicatorWindIndicatorScaleNomap.Value : sailingIndicatorWindIndicatorScale.Value;
+            return UseNomapLayout() ? sailingIndicatorWindIndicatorScaleNomap.Value : sailingIndicatorWindIndicatorScale.Value;
         }
 
         private static Vector2 GetSailingIndicatorPowerIconPosition()
         {
-            return Game.m_noMap ? sailingIndicatorPowerIconPositionNomap.Value : sailingIndicatorPowerIconPosition.Value;
+            return UseNomapLayout() ? sailingIndicatorPowerIconPositionNomap.Value : sailingIndicatorPowerIconPosition.Value;
         }
 
         private static float GetSailingIndicatorPowerIconScale()
         {
-            return Game.m_noMap ? sailingIndicatorPowerIconScaleNomap.Value : sailingIndicatorPowerIconScale.Value;
+            return UseNomapLayout() ? sailingIndicatorPowerIconScaleNomap.Value : sailingIndicatorPowerIconScale.Value;
         }
 
         private static bool GetStatusEffectsPositionEnabled()
         {
-            return Game.m_noMap ? statusEffectsPositionEnabledNomap.Value : statusEffectsPositionEnabled.Value;
+            return UseNomapLayout() ? statusEffectsPositionEnabledNomap.Value : statusEffectsPositionEnabled.Value;
         }
 
         private static bool GetStatusEffectsElementEnabled()
         {
-            return Game.m_noMap ? statusEffectsElementEnabledNomap.Value : statusEffectsElementEnabled.Value;
+            return UseNomapLayout() ? statusEffectsElementEnabledNomap.Value : statusEffectsElementEnabled.Value;
         }
     }
 }

--- a/InfoBlocks.cs
+++ b/InfoBlocks.cs
@@ -170,7 +170,7 @@ namespace MyLittleUI
 
             RectTransform rtForecast = forecastObject.GetComponent<RectTransform>();
             rtForecast.SetAnchor(forecastPositionAnchor.Value);
-            rtForecast.anchoredPosition = Game.m_noMap ? forecastPositionNomap.Value : forecastPosition.Value;
+            rtForecast.anchoredPosition = UseNomapLayout() ? forecastPositionNomap.Value : forecastPosition.Value;
             rtForecast.sizeDelta = forecastSize.Value;
 
             float height = forecastSize.Value.y;
@@ -275,12 +275,12 @@ namespace MyLittleUI
 
         internal static Vector2 GetWindsSize()
         {
-            return (Game.m_noMap ? windsSizeNomap.Value : windsSize.Value);
+            return UseNomapLayout() ? windsSizeNomap.Value : windsSize.Value;
         }
 
         private static Vector2 GetWindsPosition()
         {
-            return Game.m_noMap ? windsPositionNomap.Value : windsPosition.Value;
+            return UseNomapLayout() ? windsPositionNomap.Value : windsPosition.Value;
         }
 
         internal static void UpdateDayTimeBackground()
@@ -343,11 +343,20 @@ namespace MyLittleUI
 
         internal static void UpdateInfoBlocksVisibility()
         {
-            parentObject?.SetActive(modEnabled.Value && Minimap.instance && (Game.m_noMap ? Minimap.instance.m_mode != Minimap.MapMode.Large : Minimap.instance.m_mode == Minimap.MapMode.Small));
+            parentObject?.SetActive(modEnabled.Value && Minimap.instance && (UseNomapLayout() ? Minimap.instance.m_mode != Minimap.MapMode.Large : Minimap.instance.m_mode == Minimap.MapMode.Small));
+        }
+
+        internal static void ApplyMinimapToggle()
+        {
+            if (!Minimap.instance || Game.m_noMap || !disableMinimap.Value || Minimap.instance.m_mode != Minimap.MapMode.Small)
+                return;
+
+            Minimap.instance.SetMapMode(Minimap.MapMode.None);
         }
 
         internal static void UpdateVisibility()
         {
+            ApplyMinimapToggle();
             UpdateInfoBlocksVisibility();
 
             UpdateDayTimeText();
@@ -500,6 +509,14 @@ namespace MyLittleUI
         [HarmonyPatch(typeof(Minimap), nameof(Minimap.SetMapMode))]
         public static class Minimap_SetMapMode_UpdateInfoBlocksVisibility
         {
+            public static void Prefix([HarmonyArgument(0)] ref Minimap.MapMode mode)
+            {
+                if (!modEnabled.Value || Game.m_noMap || !disableMinimap.Value || mode != Minimap.MapMode.Small)
+                    return;
+
+                mode = Minimap.MapMode.None;
+            }
+
             public static void Postfix()
             {
                 if (!modEnabled.Value)

--- a/MyLittleUI.cs
+++ b/MyLittleUI.cs
@@ -41,6 +41,7 @@ namespace MyLittleUI
         public static ConfigEntry<bool> configLocked;
         public static ConfigEntry<bool> loggingEnabled;
         public static ConfigEntry<bool> nonlocalizedButtons;
+        public static ConfigEntry<bool> disableMinimap;
         public static ConfigEntry<bool> fixStatusEffectAndForecastPosition;
 
         public static ConfigEntry<bool> clockShowDay;
@@ -394,6 +395,11 @@ namespace MyLittleUI
                 instance.Logger.LogInfo(data);
         }
 
+        internal static bool UseNomapLayout()
+        {
+            return Game.m_noMap || (disableMinimap?.Value ?? false);
+        }
+
         private void ConfigInit()
         {
             Config.Bind("General", "NexusID", 2562, "Nexus mod ID for updates");
@@ -402,9 +408,11 @@ namespace MyLittleUI
             configLocked = config("General", "Lock Configuration", defaultValue: true, "Configuration is locked and can be changed by server admins only. [Synced with Server]", synchronizedSetting: true);
             loggingEnabled = config("General", "Logging enabled", defaultValue: false, "Enable logging.");
             nonlocalizedButtons = config("General", "Nonlocalized button keys", defaultValue: true, "Keyboard keys A-Z will not be localized in the current keyboard layout. If changed while in game then time should pass for some cached localization strings to be cleared.");
+            disableMinimap = config("General", "Disable minimap", defaultValue: false, "Disable the small minimap while keeping the large map available. Does nothing when the world is in no-map mode.");
             fixStatusEffectAndForecastPosition = config("General", "Status effects and forecast position fix", defaultValue: true, "If status effect position was not changed prior to 1.0.11 version - fix status effect list position for forecast.");
 
             modEnabled.SettingChanged += (s, e) => { InfoBlocks.UpdateVisibility(); CustomStatusEffectsList.InitializeStatusEffectTemplate(); CustomStatusEffectsList.ChangeSailingIndicator(); ZInput_GetBoundKeyString_NonlocalizedButtons.OnChange(); };
+            disableMinimap.SettingChanged += (s, e) => { InfoBlocks.ApplyMinimapToggle(); InfoBlocks.UpdateVisibility(); CustomStatusEffectsList.UpdateStatusEffectList(); };
             nonlocalizedButtons.SettingChanged += (s, e) => ZInput_GetBoundKeyString_NonlocalizedButtons.OnChange();
 
             clockShowDay = config("Info - Clock", "Show day", defaultValue: true, "Enable day number [Synced with Server]", synchronizedSetting: true);
@@ -718,6 +726,8 @@ namespace MyLittleUI
 
             statusEffectsPositionEnabledNomap.SettingChanged += (sender, args) => CustomStatusEffectsList.InitializeStatusEffectTemplate();
             statusEffectsPositionAnchorNomap.SettingChanged += (sender, args) => CustomStatusEffectsList.InitializeStatusEffectTemplate();
+            statusEffectsFillingDirectionNomap.SettingChanged += (sender, args) => CustomStatusEffectsList.InitializeStatusEffectTemplate();
+            statusEffectsPositionSpacingNomap.SettingChanged += (sender, args) => CustomStatusEffectsList.InitializeStatusEffectTemplate();
             statusEffectsElementEnabledNomap.SettingChanged += (sender, args) => CustomStatusEffectsList.InitializeStatusEffectTemplate();
             statusEffectsElementSizeNomap.SettingChanged += (sender, args) => CustomStatusEffectsList.InitializeStatusEffectTemplate();
 

--- a/WeatherForecast.cs
+++ b/WeatherForecast.cs
@@ -324,17 +324,17 @@ namespace MyLittleUI
 
         private static int GetWindsCount()
         {
-            return Game.m_noMap ? windsCountNomap.Value : windsCount.Value;
+            return UseNomapLayout() ? windsCountNomap.Value : windsCount.Value;
         }
 
         private static float GetWindsSpacing()
         {
-            return Game.m_noMap ? windsPositionSpacingNomap.Value : windsPositionSpacing.Value;
+            return UseNomapLayout() ? windsPositionSpacingNomap.Value : windsPositionSpacing.Value;
         }
 
         public static ListDirection GetWindsListDirection()
         {
-            return Game.m_noMap ? windsFillingDirectionNomap.Value : windsFillingDirection.Value;
+            return UseNomapLayout() ? windsFillingDirectionNomap.Value : windsFillingDirection.Value;
         }
 
         internal static bool IsWindListVertical()


### PR DESCRIPTION
### Motivation
- Provide a simple General toggle to disable the small minimap while keeping the large map available, matching requested UX (leave large map, hide minimap). 
- Ensure existing "nomap" layout/configs are reused when the minimap is hidden so forecast, winds and status-effects keep sensible positions and sizes. 

### Description
- Added a new config `General > Disable minimap` (`ConfigEntry<bool> disableMinimap`, default `false`) and a helper `UseNomapLayout()` that returns `Game.m_noMap || disableMinimap`. 
- Intercept `Minimap.SetMapMode` and convert attempts to set `MapMode.Small` into `MapMode.None` when the mod is enabled and the new toggle is on (but leave behavior unchanged when `Game.m_noMap` is true). 
- Reworked code paths to use `UseNomapLayout()` so `forecastPositionNomap`, `windsPositionNomap`, `windsSizeNomap`, `windsCountNomap`, `windsPositionSpacingNomap`, `windsFillingDirectionNomap` and all `Status effects - Nomap` configs are applied when the toggle is active. 
- Added `ApplyMinimapToggle()` and hooked the new config's `SettingChanged` to immediately apply the change and refresh info blocks and status effects. 

### Testing
- Ran `git diff --check` to validate whitespace and basic diff issues (no issues found). — success. 
- Attempted `dotnet build MyLittleUI.csproj` but `dotnet` is not available in the environment so a build could not be performed here. — not executed. 
- Verified repository state with `git status --short` and committed the changes locally (`Add minimap disable toggle`). — success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24616ddf908324af1fe5f237e44e97)